### PR TITLE
Chinese Simplified is zh_cn instead of zh_hk

### DIFF
--- a/pages/docs/configuration/locale-translations.mdx
+++ b/pages/docs/configuration/locale-translations.mdx
@@ -40,37 +40,33 @@ Here is a list of all the locales that are currently available in SkinsRestorer.
 
 ### Locale codes
 
-| Locale              | config value | file name           |
-|---------------------|--------------|---------------------|
-| German              | `de`         | `locale_de.json`    |
-| French              | `fr`         | `locale_fr.json`    |
-| Chinese Simplified  | `zh_cn`      | `locale_zh_cn.json` |
-| Chinese Traditional | `zh_tw`      | `locale_zh_tw.json` |
-| Polish              | `pl`         | `locale_pl.json`    |
-| Norwegian Bokmål    | `no`         | `locale_no.json`    |
-| Spanish             | `es`         | `locale_es.json`    |
-| Japanese            | `ja`         | `locale_ja.json`    |
-| Finnish             | `fi`         | `locale_fi.json`    |
-| Italian             | `it`         | `locale_it.json`    |
-| Czech               | `cs`         | `locale_cs.json`    |
-| Ukrainian           | `uk`         | `locale_uk.json`    |
-| Hungarian           | `hu`         | `locale_hu.json`    |
-| Romanian            | `ro`         | `locale_ro.json`    |
-| Turkish             | `tr`         | `locale_tr.json`    |
-| Thai                | `th`         | `locale_th.json`    |
-| Korean              | `ko`         | `locale_ko.json`    |
-| Bulgarian           | `bg`         | `locale_bg.json`    |
-| Catalan             | `ca`         | `locale_ca.json`    |
-| Danish              | `da`         | `locale_da.json`    |
-| Lithuanian          | `lt`         | `locale_it.json`    |
-| Dutch               | `nl`         | `locale_nl.json`    |
-| Arabic              | `ar`         | `locale_ar.json`    |
-
-### Specifications
-| Locale                          | config value | file name           |
-|---------------------------------|--------------|---------------------|
-| Chinese Traditional (Hong Kong) | `zh_hk`      | `locale_zh_hk.json` |
-| Canadian French                 | `fr_ca`      | `locale_fr_ca.json` |
-| Brazilian Portuguese            | `pt_br`      | `locale_pt_br.json` |
-| Argentinian Spanish             | `es_ar`      | `locale_es_ar.json` |
-| Norwegian Nynorsk               | `nn_no`      | `locale_nn_no.json` |
+| Locale                          | code    | file name           |
+|---------------------------------|---------|---------------------|
+| Arabic                          | `ar`    | `locale_ar.json`    |
+| Bulgarian                       | `bg`    | `locale_bg.json`    |
+| Catalan                         | `ca`    | `locale_ca.json`    |
+| Czech                           | `cs`    | `locale_cs.json`    |
+| Danish                          | `da`    | `locale_da.json`    |
+| German                          | `de`    | `locale_de.json`    |
+| Argentinian Spanish             | `es_ar` | `locale_es_ar.json` |
+| Spanish                         | `es`    | `locale_es.json`    |
+| Finnish                         | `fi`    | `locale_fi.json`    |
+| French                          | `fr`    | `locale_fr.json`    |
+| Canadian French                 | `fr_ca` | `locale_fr_ca.json` |
+| Hungarian                       | `hu`    | `locale_hu.json`    |
+| Italian                         | `it`    | `locale_it.json`    |
+| Japanese                        | `ja`    | `locale_ja.json`    |
+| Korean                          | `ko`    | `locale_ko.json`    |
+| Lithuanian                      | `lt`    | `locale_it.json`    |
+| Dutch                           | `nl`    | `locale_nl.json`    |
+| Norwegian Bokmål                | `no`    | `locale_no.json`    |
+| Norwegian Nynorsk               | `nn_no` | `locale_nn_no.json` |
+| Polish                          | `pl`    | `locale_pl.json`    |
+| Brazilian Portuguese            | `pt_br` | `locale_pt_br.json` |
+| Romanian                        | `ro`    | `locale_ro.json`    |
+| Thai                            | `th`    | `locale_th.json`    |
+| Turkish                         | `tr`    | `locale_tr.json`    |
+| Ukrainian                       | `uk`    | `locale_uk.json`    |
+| Simplified Chinese (China)      | `zh_cn` | `locale_zh_cn.json` |
+| Traditional Chinese (Hong Kong) | `zh_hk` | `locale_zh_hk.json` |
+| Traditional Chinese (Taiwan)    | `zh_tw` | `locale_zh_tw.json` |

--- a/pages/docs/configuration/locale-translations.mdx
+++ b/pages/docs/configuration/locale-translations.mdx
@@ -44,7 +44,7 @@ Here is a list of all the locales that are currently available in SkinsRestorer.
 |---------------------|--------------|---------------------|
 | German              | `de`         | `locale_de.json`    |
 | French              | `fr`         | `locale_fr.json`    |
-| Chinese Simplified  | `zh_hk`      | `locale_zh_hk.json` |
+| Chinese Simplified  | `zh_cn`      | `locale_zh_cn.json` |
 | Chinese Traditional | `zh_tw`      | `locale_zh_tw.json` |
 | Polish              | `pl`         | `locale_pl.json`    |
 | Norwegian Bokmål    | `no`         | `locale_no.json`    |


### PR DESCRIPTION
Last year, I renamed the file name in https://github.com/SkinsRestorer/SkinsRestorer/pull/1408, but forgot to change the docs